### PR TITLE
Set login page title to "CloudBox | Log In"

### DIFF
--- a/login.html
+++ b/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CloudBox | Sign Up</title>
+    <title>CloudBox | Log In</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
The Log In page used to say "CloudBox | Sign Up". This update fixes that.